### PR TITLE
Simplify navigation for countdown start

### DIFF
--- a/PRJ-2030/InitialSetupView.swift
+++ b/PRJ-2030/InitialSetupView.swift
@@ -6,54 +6,49 @@ struct InitialSetupView: View {
     @State private var showMainAppView: Bool = false
 
     var body: some View {
-        NavigationView {
-            VStack {
-                Spacer()
+        Group {
+            if showMainAppView {
+                MainAppView(targetDate: selectedDate)
+            } else {
+                VStack {
+                    Spacer()
 
-                Text("Welcome, time traveler! Let's embark on a journey to a future moment.")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .multilineTextAlignment(.center)
+                    Text("Welcome, time traveler! Let's embark on a journey to a future moment.")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                        .padding()
+
+                    Text("Choose a date in the future, and we'll count down to it with a quirky visual.")
+                        .font(.title2)
+                        .multilineTextAlignment(.center)
+                        .padding(.bottom, 40)
+
+                    DatePicker(
+                        "Select a Future Date",
+                        selection: $selectedDate,
+                        in: Date()..., // Ensures only future dates can be selected
+                        displayedComponents: .date
+                    )
+                    .datePickerStyle(.graphical)
                     .padding()
+                    .frame(maxWidth: 400) // Limit width for better appearance
 
-                Text("Choose a date in the future, and we'll count down to it with a quirky visual.")
+                    Button("Begin the Countdown!") {
+                        showMainAppView = true
+                    }
                     .font(.title2)
-                    .multilineTextAlignment(.center)
-                    .padding(.bottom, 40)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundColor(.white)
+                    .cornerRadius(15)
+                    .padding(.top, 30)
 
-                DatePicker(
-                    "Select a Future Date",
-                    selection: $selectedDate,
-                    in: Date()..., // Ensures only future dates can be selected
-                    displayedComponents: .date
-                )
-                .datePickerStyle(.graphical)
-                .padding()
-                .frame(maxWidth: 400) // Limit width for better appearance
-
-                Button("Begin the Countdown!") {
-                    showMainAppView = true
+                    Spacer()
                 }
-                .font(.title2)
-                .padding()
-                .background(Color.accentColor)
-                .foregroundColor(.white)
-                .cornerRadius(15)
-                .padding(.top, 30)
-
-                Spacer()
             }
-            .navigationTitle("")
-            .navigationTitle("")
-            .background(
-                NavigationLink(
-                    destination: MainAppView(targetDate: selectedDate),
-                    isActive: $showMainAppView,
-                    label: { EmptyView() }
-                )
-                .hidden()
-            )
         }
+        .animation(.default, value: showMainAppView)
     }
 }
 


### PR DESCRIPTION
## Summary
- update InitialSetupView so the countdown view replaces the start screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865dfcdb66c832ea3bb33062c3b1b26