### PR TITLE
Use American Typewriter font for onboarding

### DIFF
--- a/PRJ-2030/Font+AmericanTypewriter.swift
+++ b/PRJ-2030/Font+AmericanTypewriter.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension Font {
+    static func americanTypewriter(size: CGFloat) -> Font {
+        .custom("AmericanTypewriter", size: size)
+    }
+}

--- a/PRJ-2030/InitialSetupView.swift
+++ b/PRJ-2030/InitialSetupView.swift
@@ -11,13 +11,13 @@ struct InitialSetupView: View {
                 Spacer()
 
                 Text("Welcome, time traveler! Let's embark on a journey to a future moment.")
-                    .font(.largeTitle)
+                    .font(.americanTypewriter(size: 34))
                     .fontWeight(.bold)
                     .multilineTextAlignment(.center)
                     .padding()
 
                 Text("Choose a date in the future, and we'll count down to it with a quirky visual.")
-                    .font(.title2)
+                    .font(.americanTypewriter(size: 22))
                     .multilineTextAlignment(.center)
                     .padding(.bottom, 40)
 
@@ -28,13 +28,14 @@ struct InitialSetupView: View {
                     displayedComponents: .date
                 )
                 .datePickerStyle(.graphical)
+                .font(.americanTypewriter(size: 18))
                 .padding()
                 .frame(maxWidth: 400) // Limit width for better appearance
 
                 Button("Begin the Countdown!") {
                     showMainAppView = true
                 }
-                .font(.title2)
+                .font(.americanTypewriter(size: 22))
                 .padding()
                 .background(Color.accentColor)
                 .foregroundColor(.white)

--- a/PRJ-2030/PRJ_2030App.swift
+++ b/PRJ-2030/PRJ_2030App.swift
@@ -12,6 +12,7 @@ struct PRJ_2030App: App {
     var body: some Scene {
         WindowGroup {
             InitialSetupView()
+                .environment(\.font, .americanTypewriter(size: 17))
         }
     }
 }


### PR DESCRIPTION
## Summary
- set American Typewriter as the default font for the app
- create a helper extension for American Typewriter font
- style the initial setup screen with American Typewriter

## Testing
- `xcodebuild -list -project PRJ-2030.xcodeproj` *(fails: command not found)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6865e049310c832eb0644ff9d7c9d144